### PR TITLE
Implemented body of ip6_prefix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,7 @@ set(ENFTUN_SRCS
     src/enftun.c
     src/exec.c
     src/filter.c
+    src/icmp.c
     src/ip.c
     src/log.c
     src/options.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,7 @@ set(ENFTUN_SRCS
     src/icmp.c
     src/ip.c
     src/log.c
+    src/ndp.c
     src/options.c
     src/packet.c
     src/tcp.c

--- a/example/device.conf
+++ b/example/device.conf
@@ -61,9 +61,7 @@ route : {
   # This option is only used by the enftun-setup script.
   # table = 2097
 
-  # List of prefixes that should be routed through the tun device.
-  #
-  # This option is only used by the enftun-setup script.
+  # List of prefixes that should be routed through the tunnel.
   # prefixes = [ default ]
 
   # List of interfaces on local, trusted networks that should be

--- a/example/server.conf
+++ b/example/server.conf
@@ -51,9 +51,7 @@ route : {
   # This option is only used by the enftun-setup script.
   # table = 2097
 
-  # List of prefixes that should be routed through the tun device.
-  #
-  # This option is only used by the enftun-setup script.
+  # List of prefixes that should be routed through the tunnel.
   prefixes = [ "2607:8f80:8000::/36" ]
 
   # List of interfaces on local, trusted networks that should be

--- a/src/config.c
+++ b/src/config.c
@@ -96,6 +96,8 @@ enftun_config_init(struct enftun_config* config)
 
     config->trusted_ifaces = calloc(2, sizeof(char*));
 
+    config->ra_period = 10 * 60 * 1000; // milliseconds
+
     config->xtt_enable = 0;
     config->xtt_remote_port = "444";
     config->xtt_tcti = "device";
@@ -169,6 +171,7 @@ enftun_config_parse(struct enftun_config* config, const char* file)
     config_lookup_int(cfg, "route.table", &config->table);
     lookup_string_array(cfg, "route.prefixes", &config->prefixes);
     lookup_string_array(cfg, "route.trusted_interfaces", &config->trusted_ifaces);
+    config_lookup_int(cfg, "route.ra_period", &config->ra_period);
 
     /* Identity settings */
     config_lookup_string(cfg, "identity.cert_file", &config->cert_file);
@@ -220,6 +223,8 @@ enftun_config_print(struct enftun_config* config, const char* key)
         print_joined(config->prefixes, " ");
     else if (strcmp(key, "route.trusted_interfaces") == 0)
         print_joined(config->trusted_ifaces, " ");
+    else if (strcmp(key, "route.ra_period") == 0)
+        fprintf(stdout, "%d\n", config->ra_period);
     /* Identity settings */
     else if (strcmp(key, "identity.cert_file") == 0)
         fprintf(stdout, "%s\n", config->cert_file);

--- a/src/config.h
+++ b/src/config.h
@@ -47,6 +47,8 @@ struct enftun_config
     const char** prefixes;
     const char** trusted_ifaces;
 
+    int ra_period; /* router advertisement period in ms */
+
     int xtt_enable;
     const char* xtt_remote_port;
     const char* xtt_tcti;

--- a/src/context.h
+++ b/src/context.h
@@ -25,6 +25,7 @@
 #include "chain.h"
 #include "channel.h"
 #include "config.h"
+#include "ndp.h"
 #include "options.h"
 #include "tls.h"
 #include "tun.h"
@@ -45,6 +46,8 @@ struct enftun_context
 
     struct enftun_chain ingress;
     struct enftun_chain egress;
+
+    struct enftun_ndp ndp;
 
     uv_loop_t loop;
 

--- a/src/icmp.c
+++ b/src/icmp.c
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2019 Xaptum, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "icmp.h"
+
+#include "ip.h"
+#include "log.h"
+
+static
+uint16_t
+icmp6_cksum(struct ip6_hdr* nh, struct icmp6_hdr* th)
+{
+    uint32_t sum = 0;
+    uint16_t* w;
+    int i;
+
+    // IPv6 pseudo-header
+    //   - src and dst
+    w = (uint16_t*) &nh->ip6_src;
+    for (i = 0; i < 16; ++i)
+        sum += *w++;
+    sum += nh->ip6_plen;
+    sum += htons(nh->ip6_nxt);
+
+    // ICMP payload
+    w = (uint16_t*) th;
+    for (i = ntohs(nh->ip6_plen); i > 1; i -= 2)
+    {
+        sum += *w++;
+    }
+
+    if (i == 1)
+        sum += (uint16_t) *(uint8_t*)w;
+
+    sum += sum >> 16;
+
+    return (uint16_t) ~sum;
+}
+
+bool
+icmp6_is_nd_rs(struct enftun_packet* pkt)
+{
+    struct rs {
+        struct ip6_hdr ip6;
+        struct nd_router_solicit icmp6;
+    } *rs = (struct rs*) pkt->data;
+
+    // Start with cheap and easy checks first
+    if (sizeof(rs) > pkt->size)                                return false;
+    if (sizeof(rs->icmp6) > ntohs(rs->ip6.ip6_plen))           return false;
+
+    if (IPV6_VERSION != (rs->ip6.ip6_vfc & IPV6_VERSION_MASK)) return false;
+
+    if (IPPROTO_ICMPV6 != rs->ip6.ip6_nxt)                     return false;
+    if (ND_ROUTER_SOLICIT != rs->icmp6.nd_rs_type)             return false;
+    if (0 != rs->icmp6.nd_rs_code)                             return false;
+
+    if (0 != memcmp(&rs->ip6.ip6_dst,
+                    &ip6_all_routers,
+                    sizeof(ip6_all_routers)))                  return false;
+
+    if (0 != icmp6_cksum(&rs->ip6, &rs->icmp6.nd_rs_hdr))      return false;
+
+    return true;
+}
+
+int
+icmp6_make_nd_ra(struct enftun_packet* pkt,
+                 const struct in6_addr* src,
+                 const struct in6_addr* dst,
+                 const char** routes,
+                 int lifetime)
+{
+    struct ip6_hdr* nh = enftun_packet_insert_tail(pkt, sizeof(*nh));
+    if (!nh)
+        goto err;
+
+    nh->ip6_vfc = IPV6_VERSION;
+    nh->ip6_plen = 0; // computed below
+    nh->ip6_nxt = IPPROTO_ICMPV6;
+    nh->ip6_hlim = 255;
+    nh->ip6_src = *src;
+    nh->ip6_dst = *dst;
+
+    struct nd_router_advert* th = enftun_packet_insert_tail(pkt, sizeof(*th));
+    if (!th)
+        goto err;
+
+    th->nd_ra_type = ND_ROUTER_ADVERT;
+    th->nd_ra_code = 0;
+    th->nd_ra_cksum = 0; // computed below
+    th->nd_ra_curhoplimit = 0; // unspecified by this router
+    th->nd_ra_flags_reserved = ND_RA_FLAG_PRF_HIGH | ND_RA_FLAG_MANAGED;
+    th->nd_ra_router_lifetime = htonl(0); // not a default router
+    th->nd_ra_reachable = htonl(0); // unspecified by this router
+    th->nd_ra_retransmit = htonl(0); // unspecified by this router
+
+    struct nd_opt_mtu* mh = enftun_packet_insert_tail(pkt, sizeof(*mh));
+    if (!mh)
+        goto err;
+    mh->nd_opt_mtu_type = ND_OPT_MTU;
+    mh->nd_opt_mtu_len = 1;
+    mh->nd_opt_mtu_reserved = 0;
+    mh->nd_opt_mtu_mtu = htonl(1280);
+
+    const char* route;
+    for (route=*routes; route!=NULL; route=*++routes)
+    {
+        struct in6_addr prefix;
+        uint8_t prefixlen;
+
+        if (0 != ip6_prefix(route, &prefix, &prefixlen))
+        {
+            enftun_log_warn("ndp: skipping invalid route %s\n", route);
+            continue;
+        }
+
+        struct nd_opt_route_info* rh = enftun_packet_insert_tail(pkt, sizeof(*rh));
+        if (!rh)
+        {
+            enftun_log_warn("ndp: router advertisment full, "
+                            "skipping remaining routes\n");
+            break;
+        }
+
+        uint8_t* rh_prefix = enftun_packet_insert_tail(pkt, 16);
+        if (!rh_prefix)
+        {
+            enftun_log_warn("ndp: router advertisment full, "
+                            "skipping route: %s\n", route);
+            enftun_packet_remove_tail(pkt, sizeof(*rh));
+            continue;
+        }
+
+        rh->nd_opt_rti_type = ND_OPT_ROUTE_INFO;
+        rh->nd_opt_rti_len = 3;
+        rh->nd_opt_rti_prefixlen = prefixlen;
+        rh->nd_opt_rti_flags = ND_RA_FLAG_PRF_HIGH;
+        rh->nd_opt_rti_lifetime = htonl(lifetime);
+        memcpy(rh_prefix, &prefix, 16);
+    }
+
+    // update packet length
+    nh->ip6_plen = htons(pkt->size - sizeof(*nh));
+
+    // update checksum
+    th->nd_ra_cksum = icmp6_cksum(nh, &th->nd_ra_hdr);
+
+    return 0;
+
+ err:
+    return -1;
+}

--- a/src/icmp.h
+++ b/src/icmp.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 Xaptum, Inc.
+ * Copyright 2018-2019 Xaptum, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,176 +19,39 @@
 #ifndef ENFTUN_ICMP_H
 #define ENFTUN_ICMP_H
 
-#include "ip.h"
+#include <stdbool.h>
+#include <netinet/ip6.h>
+#include <netinet/icmp6.h>
 
-enum icmpv6_type_type
-{
-    enftun_icmpv6_echo_request         = 128,
-    enftun_icmpv6_echo_reply           = 129,
-    enftun_icmpv6_router_solicitation  = 133,
-    enftun_icmpv6_router_advertisement = 134
-};
+#include "packet.h"
 
-#pragma pack(push, 1)
-struct icmp6_hdr
-{
-    uint8_t  type;
-    uint8_t  code;
-    uint16_t checksum;
-};
+#ifndef ND_RA_FLAG_PRF_HIGH
+#define ND_RA_FLAG_PRF_HIGH 0x08
+#define ND_RA_FLAG_PRF_MEDIUM 0x00
+#define ND_RA_FLAG_PRF_LOW 0x18
+#endif
 
-/**
- * ICMP6 Router Solitication
- */
-struct icmp6_rs
-{
-    struct icmp6_hdr header;
-    uint32_t reserved;
-};
+#ifndef ND_OPT_ROUTE_INFO
+#define ND_OPT_ROUTE_INFO 24
 
-/**
- * ICMP6 Router Advertisement
- */
-struct icmp6_ra
-{
-    uint8_t  cur_hop_limit;
-    uint8_t  cfg_reserved : 2,
-             cfg_proxy    : 1,
-             cfg_prf      : 2,
-             cfg_home     : 1,
-             cfg_other    : 1,
-             cfg_managed  : 1;
-    uint16_t router_lifetime;
-    uint32_t reachable_time;
-    uint32_t retrans_timer;
-};
+struct nd_opt_route_info {/* route info */
+    u_int8_t    nd_opt_rti_type;
+    u_int8_t    nd_opt_rti_len;
+    u_int8_t    nd_opt_rti_prefixlen;
+    u_int8_t    nd_opt_rti_flags;
+    u_int32_t   nd_opt_rti_lifetime;
+    /* prefix follows */
+} __packed;
+#endif
 
-struct icmp6_opt_hdr
-{
-    uint8_t type;
-    uint8_t length;
-};
+bool
+icmp6_is_nd_rs(struct enftun_packet* pkt);
 
-struct icmp6_opt_mtu
-{
-    uint16_t reserved;
-    uint32_t mtu;
-};
-
-struct icmp6_opt_prefix
-{
-    uint8_t  prefix_length;
-    uint8_t  flags_reserved   : 5,
-             flags_router     : 1,
-             flags_autoconfig : 1,
-             flags_onlink     : 1;
-    uint32_t valid_lifetime;
-    uint32_t preferred_lifetime;
-    uint32_t reserved;
-    struct in6_addr prefix;
-};
-
-#pragma pack(pop)
-
-#include "log.h"
-
-static
-void
-icmp6_set_checksum(struct enftun_ipv6_header* iphdr, struct icmp6_hdr* icmp)
-{
-    uint32_t  sum = 0;
-    uint16_t* w;
-    int i;
-
-    icmp->checksum = 0;
-
-    // IPv6 pseudo-header
-    //   - src and dst
-    w = (uint16_t*) &iphdr->src;
-    for (i = 0; i < 16; ++i)
-        sum += *w++;
-    //   - length
-    sum += iphdr->payload_length;
-    //   - next header
-    sum += htons(58);
-
-    // ICMP payload
-    w = (uint16_t*) icmp;
-    for (i = ntohs(iphdr->payload_length); i > 1; i -= 2)
-    {
-        sum += *w++;
-    }
-
-    if (i == 1)
-        sum += (uint16_t) *(uint8_t*)w;
-
-    sum += sum >> 16;
-
-    icmp->checksum = (uint16_t) ~sum;
-}
-
-/**
-static
-void
-icmp6_build_ra(struct enftun_packet* pkt)
-{
-    struct enftun_ipv6_header* iphdr;
-    struct icmp6_hdr* icmphdr;
-    struct icmp6_ra*  icmpra;
-
-    struct icmp6_opt_hdr* opthdr;
-    struct icmp6_opt_mtu* optmtu;
-    struct icmp6_opt_prefix* optprefix;
-
-    enftun_packet_reset(pkt);
-    enftun_packet_reserve_head(pkt, sizeof(*iphdr));
-
-    icmphdr = enftun_packet_insert_tail(pkt, sizeof(*icmphdr));
-    icmphdr->type = 134;
-    icmphdr->code = 0;
-
-    icmpra = enftun_packet_insert_tail(pkt, sizeof(*icmpra));
-    icmpra->cur_hop_limit = 64;
-    icmpra->cfg_managed = 0;
-    icmpra->cfg_other = 0;
-    icmpra->cfg_prf = 1;
-    icmpra->router_lifetime = htons(1800);
-    icmpra->reachable_time = 0;
-    icmpra->retrans_timer = 0;
-
-    opthdr = enftun_packet_insert_tail(pkt, sizeof(*opthdr));
-    opthdr->type = 5;
-    opthdr->length = 1;
-
-    optmtu = enftun_packet_insert_tail(pkt, sizeof(*optmtu));
-    optmtu->mtu = htonl(1280);
-
-    opthdr = enftun_packet_insert_tail(pkt, sizeof(*opthdr));
-    opthdr->type = 3;
-    opthdr->length = 4;
-
-    optprefix = enftun_packet_insert_tail(pkt, sizeof(*optprefix));
-    optprefix->prefix_length = 64;
-    optprefix->flags_onlink = 1;
-    optprefix->flags_autoconfig = 1;
-    optprefix->flags_router = 1;
-    optprefix->valid_lifetime = -1;
-    optprefix->preferred_lifetime = -1;
-    inet_pton(AF_INET6, "2607:8f80:1234::1111", &optprefix->prefix);
-
-    size_t payload_len = pkt.size;
-
-    iphdr = enftun_packet_insert_head(pkt, sizeof(*iphdr));
-    iphdr = (struct enftun_ipv6_header*) pkt.data;
-    iphdr->version = 6;
-    iphdr->payload_length = htons(payload_len);
-    iphdr->next_header = 58;
-    iphdr->hop_limit = 255;
-    inet_pton(AF_INET6, "fe80::1111:2222:3333:4444", &iphdr->src);
-    inet_pton(AF_INET6, "ff02::1", &iphdr->dst);
-
-    icmp6_set_checksum(iphdr, icmphdr);
-}
-*/
+int
+icmp6_make_nd_ra(struct enftun_packet* pkt,
+                 const struct in6_addr* src,
+                 const struct in6_addr* dst,
+                 const char** routes,
+                 int lifetime);
 
 #endif // ENFTUN_ICMP_H

--- a/src/ip.c
+++ b/src/ip.c
@@ -77,3 +77,19 @@ int ip6_prefix_str(const struct in6_addr* addr,
 
     return 0;
 }
+
+int
+ip6_prefix(const char* str,
+           struct in6_addr* prefix,
+           uint8_t* prefixlen)
+{
+    if (0 == strcmp(str, "default"))
+    {
+        *prefix = ip6_default;
+        *prefixlen = 0;
+        return 0;
+    }
+
+    // TODO: actually parse strings of the form a:c:b::d/p
+    return -1;
+}

--- a/src/ip.h
+++ b/src/ip.h
@@ -44,4 +44,8 @@ int ip6_prefix_str(const struct in6_addr* addr,
                    const int prefix, char* dst,
                    size_t size);
 
+int ip6_prefix(const char* str,
+               struct in6_addr* prefix,
+               uint8_t* prefixlen);
+
 #endif // ENFTUN_IP_H

--- a/src/ndp.c
+++ b/src/ndp.c
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2019 Xaptum, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "ndp.h"
+
+#include <netinet/ip6.h>
+#include <netinet/icmp6.h>
+#include <string.h>
+
+#include "ip.h"
+#include "icmp.h"
+#include "log.h"
+#include "packet.h"
+
+static void send_ra(struct enftun_ndp* ndp);
+static void schedule_ra(struct enftun_ndp* ndp);
+
+static
+void
+on_timer(uv_timer_t* timer)
+{
+    struct enftun_ndp* ndp = timer->data;
+    schedule_ra(ndp);
+}
+
+static
+void
+on_write(struct enftun_crb* crb)
+{
+    struct enftun_ndp* ndp = crb->context;
+
+    if (crb->status)
+        enftun_log_error("ndp: failed to send RA: %d\n", crb->status);
+
+    ndp->ra_inflight = false;
+    if (ndp->ra_scheduled)
+        send_ra(ndp);
+}
+
+static
+void
+send_ra(struct enftun_ndp* ndp)
+{
+    ndp->ra_scheduled = false;
+    ndp->ra_inflight = true;
+
+    enftun_packet_reset(&ndp->ra_pkt);
+    icmp6_make_nd_ra(&ndp->ra_pkt, &ip6_self, &ip6_all_nodes,
+                     ndp->routes, 3 * ndp->ra_period);
+
+    enftun_crb_write(&ndp->ra_crb, ndp->chan);
+
+    // Start timer again
+    uv_timer_start(&ndp->timer, on_timer, ndp->ra_period, 0);
+}
+
+static
+void
+schedule_ra(struct enftun_ndp* ndp)
+{
+    ndp->ra_scheduled = true;
+
+    if (!ndp->ra_inflight)
+        send_ra(ndp);
+}
+
+int
+enftun_ndp_init(struct enftun_ndp* ndp,
+                struct enftun_channel* chan,
+                uv_loop_t* loop,
+                const char** routes,
+                int ra_period)
+{
+    int rc;
+
+    ndp->chan = chan;
+    ndp->routes = routes;
+    ndp->ra_period = ra_period;
+
+    ndp->ra_scheduled = false;
+    ndp->ra_inflight = false;
+
+    ndp->ra_crb.context = ndp;
+    ndp->ra_crb.packet = &ndp->ra_pkt;
+    ndp->ra_crb.complete = on_write;
+
+    ndp->timer.data = ndp;
+    rc = uv_timer_init(loop, &ndp->timer);
+
+    return rc;
+}
+
+int
+enftun_ndp_free(struct enftun_ndp* ndp)
+{
+    (void) ndp;
+
+    return 0;
+}
+
+int
+enftun_ndp_start(struct enftun_ndp* ndp)
+{
+    int rc;
+
+    rc = uv_timer_start(&ndp->timer, on_timer, 0, 0);
+
+    return rc;
+}
+
+int
+enftun_ndp_stop(struct enftun_ndp* ndp)
+{
+    uv_timer_stop(&ndp->timer);
+
+    return 0;
+}
+
+int
+enftun_ndp_handle_rs(struct enftun_ndp* ndp, struct enftun_packet* pkt)
+{
+    if (icmp6_is_nd_rs(pkt)) {
+        schedule_ra(ndp);
+        return 1;
+    }
+
+    return 0;
+}

--- a/src/ndp.h
+++ b/src/ndp.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2019 Xaptum, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#ifndef ENFTUN_NDP_H
+#define ENFTUN_NDP_H
+
+#include <stdbool.h>
+
+#include <uv.h>
+
+#include "channel.h"
+#include "packet.h"
+
+struct enftun_ndp
+{
+    struct enftun_channel* chan;
+    const char** routes;
+    int ra_period;
+
+    uv_timer_t timer;
+
+    struct enftun_packet ra_pkt;
+    struct enftun_crb ra_crb;
+
+    bool ra_inflight;
+    bool ra_scheduled;
+};
+
+int
+enftun_ndp_init(struct enftun_ndp* ndp,
+                struct enftun_channel *chan,
+                uv_loop_t* loop,
+                const char** routes,
+                int ra_period);
+
+int
+enftun_ndp_free(struct enftun_ndp* ndp);
+
+int
+enftun_ndp_start(struct enftun_ndp* ndp);
+
+int
+enftun_ndp_stop(struct enftun_ndp* ndp);
+
+int
+enftun_ndp_handle_rs(struct enftun_ndp* ndp, struct enftun_packet* pkt);
+
+#endif // ENFTUN_NDP_H


### PR DESCRIPTION
2 implementations are provided:

- a version using inet_pton(), which is easy on the eyes
  but slow due to a necessary strcpy()

- a custom version which avoids the strcpy but is about
  twice as fast